### PR TITLE
fix: InventoryWidget 드래그 상태 타입 정리

### DIFF
--- a/Team8_Project/Source/Team8_Project/Inventory/InventoryWidget.cpp
+++ b/Team8_Project/Source/Team8_Project/Inventory/InventoryWidget.cpp
@@ -76,10 +76,10 @@ void UInventoryWidget::InitInventorySlots()
 	WidgetTree->GetAllWidgets(TempWidgets);
 	for (UWidget* widget : TempWidgets)
 	{
-		UBorder* border = Cast<UBorder>(widget);
-		if (border)
+		UBorder* Findedborder = Cast<UBorder>(widget);
+		if (Findedborder)
 		{
-			Border = border;
+			Border = Findedborder;
 			break;
 		}
 	}
@@ -263,16 +263,15 @@ void UInventoryWidget::MoveStart()
 
 	//Get Boarder Position
 	FVector2D WidgetPos;
-	UCanvasPanelSlot* slot = UWidgetLayoutLibrary::SlotAsCanvasSlot(Border);
-	if (slot)
+	UCanvasPanelSlot* Borderslot = UWidgetLayoutLibrary::SlotAsCanvasSlot(Border);
+	if (Borderslot)
 	{
-		WidgetPos = slot->GetPosition();
+		WidgetPos = Borderslot->GetPosition();
 	}
 	InitialPos = WidgetPos;
 
 	//Get Mouse Position
 	InitialOffset = UWidgetLayoutLibrary::GetMousePositionOnViewport(this);
-
 }
 
 void UInventoryWidget::MoveEnd()

--- a/Team8_Project/Source/Team8_Project/Inventory/InventoryWidget.h
+++ b/Team8_Project/Source/Team8_Project/Inventory/InventoryWidget.h
@@ -104,7 +104,7 @@ private:
 
 	TObjectPtr<class UBorder> Border;
 
-	uint8 bIsDragging;
+	bool bIsDragging;
 	FVector2D InitialOffset;
 	FVector2D InitialPos;
 	


### PR DESCRIPTION
## Summary
- InventoryWidget 내부 변수명을 명확하게 정리했습니다.
- 드래그 상태 플래그를 `uint8`에서 `bool`로 변경해 의미를 분명히 했습니다.

## Why
- 위젯 드래그 로직 가독성을 높이고, 상태값의 의도를 타입으로 명확히 전달하기 위함입니다.

## Changes
- `InventoryWidget.cpp`
  - `border`/`slot` 지역 변수명을 더 명확한 이름으로 변경
- `InventoryWidget.h`
  - `bIsDragging` 타입을 `uint8` -> `bool`로 변경

## Testing
- [ ] 에디터에서 인벤토리 UI 오픈 시 슬롯 초기화 정상 동작 확인
- [ ] 드래그 시작/종료 동작에서 위치 계산이 정상인지 수동 확인

## Risks
- 동작 로직 변경은 없고 타입/명명 정리 중심이라 리스크는 낮습니다.

## Checklist
- [x] 변경 목적과 범위를 PR 본문에 기재
- [x] main 기준 변경 파일 확인
- [x] 리뷰어가 빠르게 파악할 수 있도록 핵심 변경점 정리